### PR TITLE
Drop Python 3.7 from `pyproject.toml` + Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - Use Django 3.2 in technical tests
     - Review all the Django 3.2 built-in template tags and filters (no changes needed)
 - Drop official support for Django 3.0 (still unofficially supported in this version as there are no breaking changes)
+- Remove Python 3.7 from supported versions in `pyproject.toml` (never officially supported)
 - Start keeping a changelog in `CHANGELOG.md`
 
 ## 1.0.0 - 2023-08-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.0 - Unreleased
+## 1.1.0 - 2024-02-04
 
 - Add official support for Django 3.2:
     - Use Django 3.2 in technical tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "A Django template engine to render untrusted template code"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: BSD License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django_safe_template_engine"
-version = "1.0.0"
+version = "1.1.0"
 authors = [
   { name="Ronan Boiteau", email="ronan@boiteau.eu" },
 ]


### PR DESCRIPTION
- Remove Python 3.7 from supported versions in `pyproject.toml` (never officially supported)
- Update list of changes in changelog
- Bump version number to 1.1.0
- Add release date to changelog